### PR TITLE
Implement ContextDialer.

### DIFF
--- a/connectproxy.go
+++ b/connectproxy.go
@@ -214,7 +214,7 @@ func (cd *connectDialer) DialContext(ctx context.Context, network, addr string) 
 	}
 
 	/* Connect to proxy server */
-	nc, err := cd.forward.Dial("tcp", cd.u.Host)
+	nc, err := cd.forward.DialContext(ctx, "tcp", cd.u.Host)
 	if nil != err {
 		return nil, err
 	}

--- a/connectproxy.go
+++ b/connectproxy.go
@@ -87,8 +87,8 @@ import (
 	"net/url"
 	"time"
 
-	"golang.org/x/net/proxy"
 	"encoding/base64"
+	"golang.org/x/net/proxy"
 )
 
 func init() {
@@ -234,12 +234,12 @@ func (cd *connectDialer) DialContext(ctx context.Context, network, addr string) 
 	}
 	req.Close = false
 
-	if (len(cd.config.Header) > 0) {
+	if len(cd.config.Header) > 0 {
 		req.Header = cd.config.Header
 	}
 
 	if cd.haveAuth {
-		basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(cd.username + ":" + cd.password))	
+		basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(cd.username+":"+cd.password))
 		req.Header.Add("Proxy-Authorization", basicAuth)
 	}
 

--- a/connectproxy.go
+++ b/connectproxy.go
@@ -126,20 +126,6 @@ type Config struct {
 	DialTimeout time.Duration
 }
 
-// RegisterDialerFromURL is a convenience wrapper around
-// proxy.RegisterDialerType, which registers the given URL as a for the schemes
-// "http" and/or "https", as controlled by registerHTTP and registerHTTPS.  If
-// both registerHTTP and registerHTTPS are false, RegisterDialerFromURL is a
-// no-op.
-func RegisterDialerFromURL(registerHTTP, registerHTTPS bool) {
-	if registerHTTP {
-		proxy.RegisterDialerType("http", New)
-	}
-	if registerHTTPS {
-		proxy.RegisterDialerType("https", New)
-	}
-}
-
 // connectDialer makes connections via an HTTP(s) server supporting the
 // CONNECT verb.  It implements the proxy.Dialer interface.
 type connectDialer struct {

--- a/connectproxy.go
+++ b/connectproxy.go
@@ -204,6 +204,15 @@ func GeneratorWithConfig(config *Config) func(*url.URL, proxy.ContextDialer) (pr
 
 // Dial connects to the given address via the server.
 func (cd *connectDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if cd.config.DialTimeout != 0 {
+		deadline := time.Now().Add(cd.config.DialTimeout)
+		if d, ok := ctx.Deadline(); !ok || deadline.Before(d) {
+			subCtx, cancel := context.WithDeadline(ctx, deadline)
+			defer cancel()
+			ctx = subCtx
+		}
+	}
+
 	/* Connect to proxy server */
 	nc, err := cd.forward.Dial("tcp", cd.u.Host)
 	if nil != err {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/zelch/connectproxy
+
+go 1.17
+
+require (
+	github.com/gorilla/websocket v1.4.2
+	github.com/magisterquis/connectproxy v0.0.0-20200725203833-3582e84f0c9b
+	golang.org/x/net v0.0.0-20211020060615-d418f374d309
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/magisterquis/connectproxy v0.0.0-20200725203833-3582e84f0c9b h1:xZ59n7Frzh8CwyfAapUZLSg+gXH5m63YEaFCMpDHhpI=
+github.com/magisterquis/connectproxy v0.0.0-20200725203833-3582e84f0c9b/go.mod h1:uDd4sYVYsqcxAB8j+Q7uhL6IJCs/r1kxib1HV4bgOMg=
+golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
+golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This set of changes implements proxy.ContextDialer instead of proxy.Dialer, which definitely seems to be the recommended interface these days.

With that said, it would probably make sense to implement as a v2, as there are API differences.